### PR TITLE
Add initial Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:22.04
+
+# Install Xfce desktop, VNC server, and noVNC web client
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xfce4 xfce4-terminal x11vnc tigervnc-standalone-server \
+    novnc websockify wget net-tools ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set a default VNC password (change as needed for security)
+ENV VNC_PASSWORD=password
+
+# Startup script to launch Xfce and VNC/noVNC
+COPY start.sh /start.sh
+RUN chmod +x /start.sh
+
+# Expose VNC and noVNC ports
+EXPOSE 5900 6080
+
+# Start the desktop on container run
+CMD ["/start.sh"]

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,0 +1,10 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY agent.py .
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python", "agent.py"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,19 @@
+import os
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+# Placeholder environment variables
+LLM_API_BASE_URL = os.getenv("LLM_API_BASE_URL", "http://localhost:8000/v1")
+LLM_MODEL = os.getenv("LLM_MODEL", "dummy-model")
+
+@app.route('/api/chat', methods=['POST'])
+def chat():
+    data = request.get_json(force=True)
+    prompt = data.get('prompt', '')
+    # TODO: connect to LLM and sandbox here
+    reply = f"Received: {prompt} (model={LLM_MODEL})"
+    return jsonify({'reply': reply})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3'
+services:
+  sandbox:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: sandbox
+    ports:
+      - "5900:5900"
+      - "6080:6080"
+    environment:
+      - VNC_PASSWORD=${VNC_PASSWORD:-password}
+    networks:
+      - ai_desktop_net
+    volumes:
+      - ./sandbox-data:/home
+
+  agent:
+    build:
+      context: .
+      dockerfile: Dockerfile.agent
+    container_name: agent
+    depends_on:
+      - sandbox
+    environment:
+      - LLM_API_BASE_URL=${LLM_API_BASE_URL}
+      - LLM_MODEL=${LLM_MODEL}
+      - LLM_API_KEY=${LLM_API_KEY}
+      - VNC_PASSWORD=${VNC_PASSWORD:-password}
+    networks:
+      - ai_desktop_net
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    container_name: frontend
+    depends_on:
+      - sandbox
+      - agent
+    networks:
+      - ai_desktop_net
+    ports:
+      - "8080:80"
+
+networks:
+  ai_desktop_net:
+    driver: bridge

--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head><title>AI Desktop Agent</title></head>
+<body>
+  <h2>LLM Desktop Agent Interface</h2>
+  <!-- Video feed via noVNC iframe -->
+  <div style="border:1px solid #ccc; width: 1280px; height: 720px;">
+    <iframe src="http://sandbox:6080/vnc.html?autoconnect=true&password=password" width="1280" height="720" frameborder="0"></iframe>
+  </div>
+  <!-- Chat controls -->
+  <div>
+    <input type="text" id="userInput" placeholder="Type your instruction..." size="50">
+    <button onclick="sendPrompt()">Send</button>
+  </div>
+  <pre id="chatLog" style="background:#f0f0f0; padding:10px; width:600px; height:200px; overflow:auto;"></pre>
+  <script>
+    function appendToLog(role, text) {
+      const log = document.getElementById('chatLog');
+      log.textContent += role + ": " + text + "\n";
+      log.scrollTop = log.scrollHeight;
+    }
+    async function sendPrompt() {
+      const inputEl = document.getElementById('userInput');
+      const prompt = inputEl.value;
+      if(prompt.trim() === "") return;
+      appendToLog("User", prompt);
+      inputEl.value = "";
+      try {
+        const res = await fetch('http://agent:5000/api/chat', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({ prompt: prompt })
+        });
+        const data = await res.json();
+        if(data.reply) {
+          appendToLog("Agent", data.reply);
+        } else {
+          appendToLog("Agent", "(No response)");
+        }
+      } catch(err) {
+        appendToLog("Error", "Failed to send prompt: " + err);
+      }
+    }
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+requests
+vncdotool
+Pillow

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+export DISPLAY=:1
+# Start a virtual framebuffer X server (Xvfb) in the background
+Xvfb :1 -screen 0 1280x720x24 &
+
+# Start the Xfce4 desktop session (this will connect to DISPLAY :1)
+startxfce4 &
+
+# Wait a few seconds for Xfce to start...
+sleep 2
+
+# Launch the VNC server on DISPLAY :1 with the given password
+echo "$VNC_PASSWORD" | vncpasswd -f > /root/.vnc/passwd
+chmod 600 /root/.vnc/passwd
+tigervncserver -geometry 1280x720 :1
+
+# Launch noVNC to serve a web interface on port 6080
+websockify --web=/usr/share/novnc/ --prefer-ipv4 6080 localhost:5901


### PR DESCRIPTION
## Summary
- add Dockerfiles for sandbox, agent, and frontend
- provide starter agent Python app and dependencies
- create simple HTML frontend page
- include docker-compose to wire services together

## Testing
- `python -m py_compile agent.py`


------
https://chatgpt.com/codex/tasks/task_e_685f627821d08330b126153f93532b42