### PR TITLE
Add env template and license, fix VNC port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+LLM_API_BASE_URL=http://localhost:8000/v1
+LLM_MODEL=gpt-4
+LLM_API_KEY=YOUR_API_KEY
+VNC_PASSWORD=password

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cesar Petrescu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ This project recreates the idea of [E2B's Desktop Sandbox](https://e2b.dev) enti
 
 - Linux host with Docker and Docker Compose
 - Access to an OpenAI-compatible API
-- A `.env` file containing credentials:
+- Copy `.env.example` to `.env` and fill in your credentials:
 
 ```bash
 LLM_API_BASE_URL="http://192.168.10.142:80/v1"
 LLM_MODEL="gpt-4-vision"
 LLM_API_KEY="YOUR_API_BEARER_TOKEN"
+VNC_PASSWORD="password"
 ```
 
 ## Step 1: Build the GUI Sandbox
@@ -44,14 +45,14 @@ CMD ["/start.sh"]
 
 ```bash
 #!/bin/bash
-export DISPLAY=:1
-Xvfb :1 -screen 0 1280x720x24 &
+export DISPLAY=:0
+Xvfb :0 -screen 0 1280x720x24 &
 startxfce4 &
 sleep 2
 echo "$VNC_PASSWORD" | vncpasswd -f > /root/.vnc/passwd
 chmod 600 /root/.vnc/passwd
-tigervncserver -geometry 1280x720 :1
-websockify --web=/usr/share/novnc/ --prefer-ipv4 6080 localhost:5901
+tigervncserver -geometry 1280x720 :0
+websockify --web=/usr/share/novnc/ --prefer-ipv4 6080 localhost:5900
 ```
 
 Add the service to `docker-compose.yml`:
@@ -69,6 +70,9 @@ services:
     networks:
       - ai_desktop_net
 ```
+
+The sandbox exposes its VNC server on port `5900`. Use a VNC client or the
+provided noVNC interface on port `6080` to view the desktop.
 
 ## Step 2: Build the Agent
 
@@ -192,6 +196,10 @@ docker-compose up -d --build
 ```
 
 After a short wait, open [http://<your-host>:8080](http://<your-host>:8080) and interact with the agent through the chat box while watching the sandboxed desktop.
+
+## License
+
+This project is released under the [MIT License](LICENSE).
 
 ## Conclusion
 

--- a/agent.py
+++ b/agent.py
@@ -17,7 +17,7 @@ LLM_MODEL = os.getenv("LLM_MODEL", "gpt-4")
 LLM_API_KEY = os.getenv("LLM_API_KEY")
 
 # VNC connection information
-VNC_SERVER = os.getenv("VNC_SERVER", "sandbox::5901")
+VNC_SERVER = os.getenv("VNC_SERVER", "sandbox::5900")
 VNC_PASSWORD = os.getenv("VNC_PASSWORD", "password")
 
 logging.basicConfig(level=logging.INFO)

--- a/start.sh
+++ b/start.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-export DISPLAY=:1
+export DISPLAY=:0
 # Start a virtual framebuffer X server (Xvfb) in the background
-Xvfb :1 -screen 0 1280x720x24 &
+Xvfb :0 -screen 0 1280x720x24 &
 
-# Start the Xfce4 desktop session (this will connect to DISPLAY :1)
+# Start the Xfce4 desktop session (this will connect to DISPLAY :0)
 startxfce4 &
 
 # Wait a few seconds for Xfce to start...
 sleep 2
 
-# Launch the VNC server on DISPLAY :1 with the given password
+# Launch the VNC server on DISPLAY :0 with the given password
 echo "$VNC_PASSWORD" | vncpasswd -f > /root/.vnc/passwd
 chmod 600 /root/.vnc/passwd
-tigervncserver -geometry 1280x720 :1
+tigervncserver -geometry 1280x720 :0
 
 # Launch noVNC to serve a web interface on port 6080
-websockify --web=/usr/share/novnc/ --prefer-ipv4 6080 localhost:5901
+websockify --web=/usr/share/novnc/ --prefer-ipv4 6080 localhost:5900


### PR DESCRIPTION
## Summary
- use VNC display :0 in start script
- set default VNC port to 5900 in agent
- document `.env.example` usage and note VNC port in README
- add MIT LICENSE
- provide sample `.env.example`

## Testing
- `python -m py_compile agent.py`


------
https://chatgpt.com/codex/tasks/task_e_685f6d4df7888330b4c639f1ca328977